### PR TITLE
fix: survive deletion of endpoints and linked templates

### DIFF
--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -159,8 +159,14 @@ paths:
                 properties:
                   endpoint:
                     $ref: "#/components/schemas/Endpoint"
+        "404":
+          description: Endpoint not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
-          description: Not found or invalid id
+          description: Invalid id or server error
           content:
             application/json:
               schema:
@@ -288,6 +294,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/LogListResponse"
+        "404":
+          description: Endpoint not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           description: Error
           content:
@@ -431,8 +443,14 @@ paths:
                 properties:
                   template:
                     $ref: "#/components/schemas/ResponseTemplate"
+        "404":
+          description: Template not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
-          description: Not found or invalid id
+          description: Invalid id or server error
           content:
             application/json:
               schema:

--- a/src/app/backend/endpoint/[endpointId]/route.ts
+++ b/src/app/backend/endpoint/[endpointId]/route.ts
@@ -22,7 +22,9 @@ const getEndpointById = async (endpointId: number) => {
   try {
     const endpoint = await endpointService.getEndpointById(endpointId)
     return NextResponse.json({ endpoint })
-  } catch {
+  } catch (error) {
+    if ((error as Error).message === "Endpoint not found")
+      return NextResponse.json({ error: "Endpoint not found" }, { status: 404 })
     return NextResponse.json({ error: "Error while executing request" }, { status: 500 })
   }
 }

--- a/src/app/backend/log/route.ts
+++ b/src/app/backend/log/route.ts
@@ -16,7 +16,7 @@ export const GET = async (request: Request) => {
 
   try {
     const endpoint = await endpointService.getEndpointById(endpointId)
-    if (endpoint instanceof Error) return
+    if (endpoint instanceof Error) throw endpoint
 
     const pagination = getPaginationQuery(request)
     const filters: Partial<LogListFilters> = {
@@ -31,6 +31,8 @@ export const GET = async (request: Request) => {
 
     return NextResponse.json(response)
   } catch (error) {
-    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+    const message = (error as Error).message
+    const status = message === "Endpoint not found" ? 404 : 500
+    return NextResponse.json({ error: message }, { status })
   }
 }

--- a/src/app/backend/template/[templateId]/route.ts
+++ b/src/app/backend/template/[templateId]/route.ts
@@ -22,7 +22,9 @@ const getTemplateById = async (templateId: number) => {
   try {
     const template = await templateService.getTemplateById(templateId)
     return NextResponse.json({ template })
-  } catch {
+  } catch (error) {
+    if ((error as Error).message === "Template not found")
+      return NextResponse.json({ error: "Template not found" }, { status: 404 })
     return NextResponse.json({ error: "Error while executing request" }, { status: 500 })
   }
 }

--- a/src/app/services/template.service.ts
+++ b/src/app/services/template.service.ts
@@ -45,11 +45,23 @@ class TemplateService {
     const exists = await DB.models.ResponseTemplate.findByPk(id)
     if (!exists?.id) throw new Error("Template not found")
 
+    // SQLite does not enforce the ON DELETE SET NULL association here, so clean the
+    // references explicitly — otherwise endpoints keep pointing at a deleted template.
+    const transaction = await DB.sequelize.transaction()
+
     try {
-      await DB.models.ResponseTemplate.destroy({ where: { id } })
+      await DB.models.EndpointTemplateReference.destroy({ where: { template_id: id }, transaction })
+      await DB.models.Endpoint.update(
+        { response_template_id: null },
+        { where: { response_template_id: id }, transaction }
+      )
+      await DB.models.ResponseTemplate.destroy({ where: { id }, transaction })
+
+      await transaction.commit()
       return true
-    } catch {
-      return false
+    } catch (error) {
+      await transaction.rollback()
+      throw error
     }
   }
 

--- a/src/app/services/template.service.ts
+++ b/src/app/services/template.service.ts
@@ -45,8 +45,6 @@ class TemplateService {
     const exists = await DB.models.ResponseTemplate.findByPk(id)
     if (!exists?.id) throw new Error("Template not found")
 
-    // SQLite does not enforce the ON DELETE SET NULL association here, so clean the
-    // references explicitly — otherwise endpoints keep pointing at a deleted template.
     const transaction = await DB.sequelize.transaction()
 
     try {

--- a/src/ui/sections/Endpoints/ListWithLogs/index.tsx
+++ b/src/ui/sections/Endpoints/ListWithLogs/index.tsx
@@ -59,6 +59,9 @@ export const ListWithLogs: FC<Props> = ({ activeEndpoint }) => {
     setLogs(listInitial)
     getLogs()
     startUpdateInterval()
+    // Without this cleanup a stale interval keeps polling the previous endpoint
+    // (e.g. one that was just deleted) after navigating away.
+    return stopUpdateInterval
   }, [endpointId, page, limit, ...filtersList])
 
   useEffect(() => {
@@ -102,7 +105,13 @@ export const ListWithLogs: FC<Props> = ({ activeEndpoint }) => {
       limit,
       ...filters
     })
-    if (response instanceof Error) return setIsLogsLoading(false)
+    // An error payload (endpoint deleted, backend failure) has no items/pagination:
+    // rendering it would crash and polling it further is pointless.
+    if (response instanceof Error || !response?.pagination) {
+      stopUpdateInterval()
+      setIsLogsLoading(false)
+      return
+    }
     setLogs(response)
     setIsLogsLoading(false)
   }
@@ -125,8 +134,12 @@ export const ListWithLogs: FC<Props> = ({ activeEndpoint }) => {
   }
 
   const startUpdateInterval = () => {
-    if (updateInterval.current) clearInterval(updateInterval.current)
+    stopUpdateInterval()
     if (page === 1) updateInterval.current = setInterval(() => getLogs(false), REFRESH_LOGS_INTERVAL)
+  }
+
+  const stopUpdateInterval = () => {
+    if (updateInterval.current) clearInterval(updateInterval.current)
   }
 
   if (!activeEndpoint) return <Cap title="Endpoints requests" description="Select endpoint to see the request logs" />
@@ -171,9 +184,7 @@ export const ListWithLogs: FC<Props> = ({ activeEndpoint }) => {
               </Card.Container>
             )}
 
-            <div>
-              <Pagination pagination={logs.pagination} />
-            </div>
+            <div>{logs?.pagination && <Pagination pagination={logs.pagination} />}</div>
           </div>
           <div>
             {activeLog && (

--- a/src/ui/sections/Endpoints/ListWithLogs/index.tsx
+++ b/src/ui/sections/Endpoints/ListWithLogs/index.tsx
@@ -59,8 +59,6 @@ export const ListWithLogs: FC<Props> = ({ activeEndpoint }) => {
     setLogs(listInitial)
     getLogs()
     startUpdateInterval()
-    // Without this cleanup a stale interval keeps polling the previous endpoint
-    // (e.g. one that was just deleted) after navigating away.
     return stopUpdateInterval
   }, [endpointId, page, limit, ...filtersList])
 
@@ -105,8 +103,6 @@ export const ListWithLogs: FC<Props> = ({ activeEndpoint }) => {
       limit,
       ...filters
     })
-    // An error payload (endpoint deleted, backend failure) has no items/pagination:
-    // rendering it would crash and polling it further is pointless.
     if (response instanceof Error || !response?.pagination) {
       stopUpdateInterval()
       setIsLogsLoading(false)

--- a/src/ui/sections/Endpoints/index.tsx
+++ b/src/ui/sections/Endpoints/index.tsx
@@ -46,7 +46,9 @@ const Endpoints: NextPage = () => {
     try {
       const response = await API.deleteEndpoint(id)
       if (!response.success) return failureToast("Error deleting endpoint")
-      if (activeEndpoint?.id === id) router.push("/endpoints", undefined, { scroll: false, shallow: true })
+      // Compare against the route param, not activeEndpoint state, which can lag
+      // behind navigation and skip the redirect away from the deleted endpoint.
+      if (endpointId === id) router.push("/endpoints", undefined, { scroll: false, shallow: true })
       getEndpoints(false)
       successToast("Endpoint deleted")
     } catch (error) {

--- a/src/ui/sections/Endpoints/index.tsx
+++ b/src/ui/sections/Endpoints/index.tsx
@@ -46,8 +46,6 @@ const Endpoints: NextPage = () => {
     try {
       const response = await API.deleteEndpoint(id)
       if (!response.success) return failureToast("Error deleting endpoint")
-      // Compare against the route param, not activeEndpoint state, which can lag
-      // behind navigation and skip the redirect away from the deleted endpoint.
       if (endpointId === id) router.push("/endpoints", undefined, { scroll: false, shallow: true })
       getEndpoints(false)
       successToast("Endpoint deleted")


### PR DESCRIPTION
## What

Two delete flows reported broken on the demo instance:

1. **Deleting an endpoint while viewing its logs crashed the entire UI** — `Application error: a client-side exception has occurred`, console showed `TypeError: Cannot destructure property 'total' of 'e' as it is undefined` plus 500s from `/backend/endpoint/{id}/logs`.
2. **Deleting a template linked to an endpoint** "worked", but left errors behind (500 from `/backend/template/{id}`) and dangling references.

## Root causes

- `ListWithLogs`'s 5-second refresh effect returned early without a cleanup, so a **stale interval kept polling the deleted endpoint**; the error payload was written into state and `Pagination` destructured `undefined` → app-wide crash.
- The redirect after delete compared against `activeEndpoint` state, which lags behind navigation.
- `deleteTemplate` relied on the `ON DELETE SET NULL` association, which **SQLite does not enforce** (`PRAGMA foreign_keys` is off) — endpoints kept pointing at deleted templates, and the follow-up template fetch 500'd.
- Missing endpoint/template/logs returned **500 instead of 404** (`/backend/log`'s guard even returned `undefined` from the handler).

## Fixes

- `ListWithLogs`: interval cleared via effect cleanup; polling stops on error payloads; responses without `pagination` are never stored; `Pagination` renders only when pagination exists
- `Endpoints`: post-delete redirect keyed on the route param
- `TemplateService.deleteTemplate`: clears `endpoint_template_references` and nulls `endpoints.response_template_id` in one transaction with the destroy; throws instead of swallowing failures
- 404 for missing endpoint / template / endpoint logs (spec updated accordingly, `openapi:validate` green)

## Verified

Local E2E on a fresh build: missing ids → 404, existing → 200; deleting a linked template returns `success:true`, nulls the endpoint's `response_template_id`, leaves zero orphaned reference rows, and the mock keeps answering. `pnpm lint`, `type`, `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)